### PR TITLE
Override log_entries partial for card_pointe payments

### DIFF
--- a/app/overrides/spree/admin/payments/card_pointe_log_entries.rb
+++ b/app/overrides/spree/admin/payments/card_pointe_log_entries.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Spree
+  module Admin
+    module Payments
+      class CardPointeLogEntries
+        def self.call
+          Deface::Override.new(
+            virtual_path: 'spree/admin/payments/_log_entries',
+            name: 'card_pointe_log_entries',
+            original: '5eb2952fa4ba1484a63e5abf53e4ed735761a7b2',
+            replace: 'table#listing_log_entries',
+            partial: 'spree/admin/payments/source_views/card_pointe_log_entries',
+            disabled: false
+          )
+        end
+      end
+    end
+  end
+end
+
+Spree::Admin::Payments::CardPointeLogEntries.call

--- a/app/views/spree/admin/payments/source_views/_card_pointe_log_entries.html.erb
+++ b/app/views/spree/admin/payments/source_views/_card_pointe_log_entries.html.erb
@@ -1,0 +1,22 @@
+<% if @payment.payment_method.is_a?(SolidusCardPointe::PaymentMethod) %>
+  <table class="index" id="listing_card_pointe_log_entries">
+    <thead>
+      <tr>
+        <th><%= Spree::LogEntry.human_attribute_name(:created_at) %></th>
+        <th><%= Spree::LogEntry.human_attribute_name(:details) %></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @payment.log_entries.each do |entry| %>
+        <tr>
+          <td><%= pretty_time(entry.created_at) %></td>
+          <td>
+            <pre><%= entry.parsed_details.message %></pre>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% else %>
+  <%= render partial: 'spree/admin/payments/log_entries', locals: { payment: payment } %>
+<% end %> 


### PR DESCRIPTION
The Sandbox app has [solidus_paypal_commerce_platform](https://github.com/solidusio/solidus_paypal_commerce_platform) gem by default. This gem overrides the log_entries partial, adding a PayPal debug ID column to the log table. To avoid this, this PR overrides the partial for every payment that's a card_pointe payment. 
The log_entries will look like this :
<img width="1429" alt="Screenshot 2024-12-02 at 17 24 04" src="https://github.com/user-attachments/assets/e16c6d2c-065f-406e-aac3-3034154b741d">
