### PR TITLE
Save and show card information for card pointe payment sources

### DIFF
--- a/app/models/solidus_card_pointe/payment_source.rb
+++ b/app/models/solidus_card_pointe/payment_source.rb
@@ -4,5 +4,28 @@ require_dependency 'solidus_card_pointe'
 
 module SolidusCardPointe
   class PaymentSource < SolidusSupport.payment_source_parent_class
+    before_save :populate_card_details
+
+    private
+
+    def populate_card_details
+      self.card_type = determine_card_type
+      self.card_last4 = card_token[-4..-1]
+    end
+
+    def determine_card_type
+      case card_token[0..1]
+      when '93'
+        'Amex'
+      when '94'
+        'Visa'
+      when '95'
+        'MasterCard'
+      when '96'
+        'Discover'
+      else
+        'Unknown'
+      end
+    end
   end
 end

--- a/app/views/spree/admin/payments/source_views/_card_pointe.html.erb
+++ b/app/views/spree/admin/payments/source_views/_card_pointe.html.erb
@@ -1,0 +1,7 @@
+<% formatted_card_number = "#{@payment.source.card_token[1..2]}XX-XXXX-XXXX-#{@payment.source.card_last4}" %>
+
+<div>
+    <legend align="center"> <%= ::SolidusCardPointe::PaymentMethod.model_name.human %></legend>
+    <p>Card Number: <b><%= formatted_card_number %></b></p>
+    <p>Card Type: <b><%= @payment.source.card_type %></b></p>
+</div>

--- a/db/migrate/20241203145821_add_card_information_to_payment_source.rb
+++ b/db/migrate/20241203145821_add_card_information_to_payment_source.rb
@@ -1,0 +1,6 @@
+class AddCardInformationToPaymentSource < ActiveRecord::Migration[7.2]
+  def change
+    add_column :solidus_card_pointe_payment_sources, :card_last4, :string
+    add_column :solidus_card_pointe_payment_sources, :card_type, :string
+  end
+end

--- a/spec/models/solidus_card_pointe/payment_source_spec.rb
+++ b/spec/models/solidus_card_pointe/payment_source_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper'
+
+RSpec.describe SolidusCardPointe::PaymentSource, type: :model do
+  describe '#populate_card_details' do
+    let(:payment_source) { described_class.new(card_token: card_token) }
+
+    before { payment_source.send(:populate_card_details) }
+
+    context 'when card_token starts with 93' do
+      let(:card_token) { '9312345678901234' }
+
+      it 'sets card_type to Amex' do
+        expect(payment_source.card_type).to eq('Amex')
+      end
+
+      it 'sets card_last4 to the last 4 digits of card_token' do
+        expect(payment_source.card_last4).to eq('1234')
+      end
+    end
+
+    context 'when card_token starts with 94' do
+      let(:card_token) { '9412345678901234' }
+
+      it 'sets card_type to Visa' do
+        expect(payment_source.card_type).to eq('Visa')
+      end
+
+      it 'sets card_last4 to the last 4 digits of card_token' do
+        expect(payment_source.card_last4).to eq('1234')
+      end
+    end
+
+    context 'when card_token starts with 95' do
+      let(:card_token) { '9512345678901234' }
+
+      it 'sets card_type to MasterCard' do
+        expect(payment_source.card_type).to eq('MasterCard')
+      end
+
+      it 'sets card_last4 to the last 4 digits of card_token' do
+        expect(payment_source.card_last4).to eq('1234')
+      end
+    end
+
+    context 'when card_token starts with 96' do
+      let(:card_token) { '9612345678901234' }
+
+      it 'sets card_type to Discover' do
+        expect(payment_source.card_type).to eq('Discover')
+      end
+
+      it 'sets card_last4 to the last 4 digits of card_token' do
+        expect(payment_source.card_last4).to eq('1234')
+      end
+    end
+
+    context 'when card_token starts with an unknown prefix' do
+      let(:card_token) { '0012345678901234' }
+
+      it 'sets card_type to Unknown' do
+        expect(payment_source.card_type).to eq('Unknown')
+      end
+
+      it 'sets card_last4 to the last 4 digits of card_token' do
+        expect(payment_source.card_last4).to eq('1234')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Card Pointe source view: 

<img width="1429" alt="Screenshot 2024-12-03 at 17 00 00" src="https://github.com/user-attachments/assets/83fea18b-b503-45b6-9c1d-deb243c9a5cb">
