### PR TITLE
Fix unknown migration version error

### DIFF
--- a/db/migrate/20241203145821_add_card_information_to_payment_source.rb
+++ b/db/migrate/20241203145821_add_card_information_to_payment_source.rb
@@ -1,4 +1,4 @@
-class AddCardInformationToPaymentSource < ActiveRecord::Migration[7.2]
+class AddCardInformationToPaymentSource < ActiveRecord::Migration[7.0]
   def change
     add_column :solidus_card_pointe_payment_sources, :card_last4, :string
     add_column :solidus_card_pointe_payment_sources, :card_type, :string

--- a/solidus_card_pointe.gemspec
+++ b/solidus_card_pointe.gemspec
@@ -31,8 +31,8 @@ Gem::Specification.new do |spec|
   spec.executables = files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'httparty'
   spec.add_dependency 'deface'
+  spec.add_dependency 'httparty'
   spec.add_dependency 'solidus_core', ['>= 2.0.0', '< 5']
   spec.add_dependency 'solidus_support', '~> 0.5'
 

--- a/spec/models/solidus_card_pointe/payment_method_spec.rb
+++ b/spec/models/solidus_card_pointe/payment_method_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe SolidusCardPointe::PaymentMethod do
     end
   end
 
+  # rubocop:disable RSpec/MultipleMemoizedHelpers
   describe '#reusable_sources' do
     let(:reusable_payment_source) {
       instance_double(SolidusCardPointe::PaymentSource, reusable?: true, payment_method: payment_method)
@@ -71,4 +72,5 @@ RSpec.describe SolidusCardPointe::PaymentMethod do
       expect(payment_method.reusable_sources(order)).to contain_exactly(reusable_payment_source)
     end
   end
+  # rubocop:enable RSpec/MultipleMemoizedHelpers
 end


### PR DESCRIPTION
Fixing this error:

> ArgumentError: Unknown migration version "7.2"; expected one of "4.2", "5.0", "5.1", "5.2", "6.0", "6.1", "7.0"
> /home/circleci/project/spec/dummy/db/migrate/20241225165377_add_card_information_to_payment_source.solidus_card_pointe.rb:2:in `<top (required)>'
> 
> Caused by:
> ArgumentError: Unknown migration version "7.2"; expected one of "4.2", "5.0", "5.1", "5.2", "6.0", "6.1", "7.0"
> /home/circleci/project/spec/dummy/db/migrate/20241225165377_add_card_information_to_payment_source.solidus_card_pointe.rb:2:in `<top (required)>'
> Tasks: TOP => db:migrate
> (See full trace by running task with --trace)
> rake aborted!
> Command failed with status (1): [bin/rails db:drop db:create db:migrate VERBOSE=false RAILS_ENV=test]