### PR TITLE
Remove deprecated SolidusSupport parent classes

### DIFF
--- a/app/models/solidus_card_pointe/payment_method.rb
+++ b/app/models/solidus_card_pointe/payment_method.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module SolidusCardPointe
-  class PaymentMethod < SolidusSupport.payment_method_parent_class
+  class PaymentMethod < Spree::PaymentMethod
     preference :card_pointe_merchant_id, :string
     preference :card_pointe_authorization, :string
     preference :card_pointe_domain, :string

--- a/app/models/solidus_card_pointe/payment_source.rb
+++ b/app/models/solidus_card_pointe/payment_source.rb
@@ -3,7 +3,7 @@
 require_dependency 'solidus_card_pointe'
 
 module SolidusCardPointe
-  class PaymentSource < SolidusSupport.payment_source_parent_class
+  class PaymentSource < Spree::PaymentSource
     before_save :populate_card_details
 
     def reusable?


### PR DESCRIPTION
Fixing:

> DEPRECATION WARNING: SolidusSupport.payment_source_parent_class is deprecated and will be removed in solidus_support 1.0. Please use Spree::PaymentSource instead.